### PR TITLE
Fix new user sign-in after email confirmation

### DIFF
--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -67,10 +67,9 @@ export const SignInForm = () => {
         timestamp: new Date().toISOString()
       });
       
-      // Successful sign-in will trigger the middleware to redirect the user
-      // to the correct page (onboarding or dashboard).
-      // We just need to refresh the page to trigger the middleware check.
-      router.refresh();
+      // After sign-in, send users away from the auth page to let middleware route them.
+      // Using push avoids being stuck on the same route while cookies update.
+      router.push('/dashboard');
     }
   };
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -70,9 +70,15 @@ export async function middleware(request: NextRequest) {
 
     const { data: profile } = await supabase.from('profiles').select('onboarding_complete, role').eq('id', user.id).single();
 
+    // If profile doesn't exist yet (e.g., just confirmed email and trigger hasn't run),
+    // send the user to the correct onboarding flow instead of signing them out.
     if (!profile) {
-        await supabase.auth.signOut();
-        return NextResponse.redirect(new URL('/auth/sign-in', request.url));
+        const roleFromMetadata = (user.user_metadata as any)?.role ?? 'student';
+        const onboardingUrl = `/onboarding/${roleFromMetadata}`;
+        if (pathname !== onboardingUrl) {
+            return NextResponse.redirect(new URL(onboardingUrl, request.url));
+        }
+        return response;
     }
     
     // Handle onboarding redirection


### PR DESCRIPTION
Fix new user sign-in flow to prevent getting stuck and correctly route to onboarding.

The previous implementation caused new users to get stuck on "Signing In..." after email confirmation. This was because the sign-in form only refreshed the page, and the middleware would sign out users without a profile instead of directing them to complete their role-based onboarding.

---
<a href="https://cursor.com/background-agent?bcId=bc-4b63d13e-1a84-4d9b-a903-b80c7193a3e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4b63d13e-1a84-4d9b-a903-b80c7193a3e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

